### PR TITLE
Extract state objects for record/replay modes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    impersonator (0.1.2)
+    impersonator (0.1.3)
       zeitwerk (~> 2.1.6)
 
 GEM

--- a/lib/impersonator/proxy.rb
+++ b/lib/impersonator/proxy.rb
@@ -67,14 +67,8 @@ module Impersonator
       matching_configuration = method_matching_configurations_by_method[method_name.to_sym]
       method = Method.new(name: method_name, arguments: args, block: block,
                           matching_configuration: matching_configuration)
-      if recording.replay_mode?
-        recording.replay(method)
-      else
-        spiable_block = method&.block_spy&.block
-        @impersonated_object.send(method_name, *args, &spiable_block).tap do |return_value|
-          recording.record(method, return_value)
-        end
-      end
+      recording.invoke(@impersonated_object, method, args)
     end
+
   end
 end

--- a/lib/impersonator/proxy.rb
+++ b/lib/impersonator/proxy.rb
@@ -69,6 +69,5 @@ module Impersonator
                           matching_configuration: matching_configuration)
       recording.invoke(@impersonated_object, method, args)
     end
-
   end
 end

--- a/lib/impersonator/record_mode.rb
+++ b/lib/impersonator/record_mode.rb
@@ -1,0 +1,56 @@
+module Impersonator
+  # The state of a {Recording recording} in record mode
+  class RecordMode
+    include HasLogger
+
+    # recording file path
+    attr_reader :recording_path
+
+    # @param [String] recording_path the file path to the recording file
+    def initialize(recording_path)
+      @recording_path = recording_path
+    end
+
+    # Start a recording session
+    def start
+      logger.debug 'Recording mode'
+      make_sure_recordings_dir_exists
+      @method_invocations = []
+    end
+
+    # Records the method invocation
+    #
+    # @param [Object, Double] impersonated_object
+    # @param [MethodInvocation] method
+    # @param [Array<Object>] args
+    def invoke(impersonated_object, method, args)
+      spiable_block = method&.block_spy&.block
+      impersonated_object.send(method.name, *args, &spiable_block).tap do |return_value|
+        record(method, return_value)
+      end
+    end
+
+    # Finishes the record session
+    def finish
+      File.open(recording_path, 'w') do |file|
+        YAML.dump(@method_invocations, file)
+      end
+    end
+
+    private
+
+    # Record a {MethodInvocation method invocation} with a given return value
+    # @param [Method] method
+    # @param [Object] return_value
+    def record(method, return_value)
+      method_invocation = MethodInvocation.new(method_instance: method, return_value: return_value)
+
+      @method_invocations << method_invocation
+    end
+
+    def make_sure_recordings_dir_exists
+      dirname = File.dirname(recording_path)
+      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
+    end
+  end
+end

--- a/lib/impersonator/recording.rb
+++ b/lib/impersonator/recording.rb
@@ -3,6 +3,21 @@
 module Impersonator
   # A recording is responsible for saving interactions at record time, and replaying them at
   # replay time.
+  #
+  # A recording is always in one of two states.
+  #
+  # * {RecordMode Record mode}
+  # * {ReplayMode Replay mode}
+  #
+  # The state objects are responsible of dealing with the recording logic, which happens in 3
+  # moments:
+  #
+  # * {#start}
+  # * {#invoke}
+  # * {#finish}
+  #
+  # @see RecordMode
+  # @see ReplayMode
   class Recording
     include HasLogger
 
@@ -15,44 +30,39 @@ module Impersonator
       @label = label
       @recordings_path = recordings_path
       @disabled = disabled
+
+      initialize_current_mode
     end
 
     # Start a recording/replay session
     def start
       logger.debug "Starting recording #{label}..."
-      if can_replay?
-        start_in_replay_mode
-      else
-        start_in_record_mode
-      end
+      current_mode.start
     end
 
+    # Handles the invocation of a given method on the impersonated object
+    #
+    # It will either record the interaction or replay it dependening on if there
+    # is a recording available or not
+    #
+    # @param [Object, Double] impersonated_object
+    # @param [MethodInvocation] method
+    # @param [Array<Object>] args
     def invoke(impersonated_object, method, args)
-      if replay_mode?
-        replay(method)
-      else
-        spiable_block = method&.block_spy&.block
-        impersonated_object.send(method.name, *args, &spiable_block).tap do |return_value|
-          record(method, return_value)
-        end
-      end
+      current_mode.invoke(impersonated_object, method, args)
     end
 
     # Finish a record/replay session.
     def finish
       logger.debug "Recording #{label} finished"
-      if record_mode?
-        finish_in_record_mode
-      else
-        finish_in_replay_mode
-      end
+      current_mode.finish
     end
 
     # Return whether it is currently at replay mode
     #
     # @return [Boolean]
     def replay_mode?
-      @replay_mode
+      @current_mode == replay_mode
     end
 
     # Return whether it is currently at record mode
@@ -64,90 +74,34 @@ module Impersonator
 
     private
 
+    attr_reader :current_mode
+
+    def initialize_current_mode
+      @current_mode = if can_replay?
+                        replay_mode
+                      else
+                        record_mode
+                      end
+    end
+
     def can_replay?
-      !@disabled && File.exist?(file_path)
+      !@disabled && File.exist?(recording_path)
     end
 
-    # Record a {MethodInvocation method invocation} with a given return value
-    # @param [Method] method
-    # @param [Object] return_value
-    def record(method, return_value)
-      method_invocation = MethodInvocation.new(method_instance: method, return_value: return_value)
-
-      @method_invocations << method_invocation
+    def record_mode
+      @record_mode ||= RecordMode.new(recording_path)
     end
 
-    # Replay a method invocation
-    # @param [Method] method
-    def replay(method)
-      method_invocation = @method_invocations.shift
-      unless method_invocation
-        raise Impersonator::Errors::MethodInvocationError, 'Unexpected method invocation received:'\
-              "#{method}"
-      end
-
-      validate_method_signature!(method, method_invocation.method_instance)
-      replay_block(method_invocation, method)
-
-      method_invocation.return_value
+    def replay_mode
+      @replay_mode ||= ReplayMode.new(recording_path)
     end
 
-    def replay_block(recorded_method_invocation, method_to_replay)
-      block_spy = recorded_method_invocation.method_instance.block_spy
-      block_spy&.block_invocations&.each do |block_invocation|
-        method_to_replay.block.call(*block_invocation.arguments)
-      end
-    end
-
-    def start_in_replay_mode
-      logger.debug 'Replay mode'
-      @replay_mode = true
-      @method_invocations = YAML.load_file(file_path)
-    end
-
-    def start_in_record_mode
-      logger.debug 'Recording mode'
-      @replay_mode = false
-      make_sure_recordings_dir_exists
-      @method_invocations = []
-    end
-
-    def finish_in_record_mode
-      File.open(file_path, 'w') do |file|
-        YAML.dump(@method_invocations, file)
-      end
-    end
-
-    def finish_in_replay_mode
-      unless @method_invocations.empty?
-        raise Impersonator::Errors::MethodInvocationError,
-              "Expecting #{@method_invocations.length} method invocations"\
-              " that didn't happen: #{@method_invocations.inspect}"
-      end
-    end
-
-    def file_path
+    def recording_path
       File.join(@recordings_path, "#{label_as_file_name}.yml")
     end
 
     def label_as_file_name
       label.downcase.gsub(/[\(\)\s \#:]/, '-').gsub(/[\-]+/, '-').gsub(/(^-)|(-$)/, '')
-    end
-
-    def make_sure_recordings_dir_exists
-      dirname = File.dirname(file_path)
-      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
-    end
-
-    def validate_method_signature!(expected_method, actual_method)
-      unless actual_method == expected_method
-        raise Impersonator::Errors::MethodInvocationError, <<~ERROR
-          Expecting:
-            #{expected_method}
-          But received:
-            #{actual_method}
-        ERROR
-      end
     end
   end
 end

--- a/lib/impersonator/replay_mode.rb
+++ b/lib/impersonator/replay_mode.rb
@@ -1,0 +1,68 @@
+module Impersonator
+  # The state of a {Recording recording} in replay mode
+  class ReplayMode
+    include HasLogger
+
+    # recording file path
+    attr_reader :recording_path
+
+    # @param [String] recording_path the file path to the recording file
+    def initialize(recording_path)
+      @recording_path = recording_path
+    end
+
+    # Start a replay session
+    def start
+      logger.debug 'Replay mode'
+      @replay_mode = true
+      @method_invocations = YAML.load_file(recording_path)
+    end
+
+    # Replays the method invocation
+    #
+    # @param [Object, Double] impersonated_object not used in replay mode
+    # @param [MethodInvocation] method
+    # @param [Array<Object>] args not used in replay mode
+    def invoke(_impersonated_object, method, _args)
+      method_invocation = @method_invocations.shift
+      unless method_invocation
+        raise Impersonator::Errors::MethodInvocationError, 'Unexpected method invocation received:'\
+              "#{method}"
+      end
+
+      validate_method_signature!(method, method_invocation.method_instance)
+      replay_block(method_invocation, method)
+
+      method_invocation.return_value
+    end
+
+    # Finishes the record session
+    def finish
+      unless @method_invocations.empty?
+        raise Impersonator::Errors::MethodInvocationError,
+              "Expecting #{@method_invocations.length} method invocations"\
+              " that didn't happen: #{@method_invocations.inspect}"
+      end
+    end
+
+    private
+
+    def replay_block(recorded_method_invocation, method_to_replay)
+      block_spy = recorded_method_invocation.method_instance.block_spy
+      block_spy&.block_invocations&.each do |block_invocation|
+        method_to_replay.block.call(*block_invocation.arguments)
+      end
+    end
+
+    def validate_method_signature!(expected_method, actual_method)
+      unless actual_method == expected_method
+        raise Impersonator::Errors::MethodInvocationError, <<~ERROR
+          Expecting:
+            #{expected_method}
+          But received:
+            #{actual_method}
+        ERROR
+      end
+    end
+  end
+end

--- a/lib/impersonator/version.rb
+++ b/lib/impersonator/version.rb
@@ -1,3 +1,3 @@
 module Impersonator
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end


### PR DESCRIPTION
This is an internal change making 2 improvements:

- It moves the responsibility of deciding to either record or replay from `Proxy` to 
`Recording`. 

  This keeps `Proxy` focused on its thing, treating the recording as a black box. `Recording` 
already had all it needed to make this decision.

- It extracts out the state-based logic of recording/replaying to proper state objects.

  This removes the repeated conditional logic (`if replay_mode?`) and encapsulates 
each responsibility in their own class instead of having both concerns mixed in `Recording`. 
The `recording` now simply relies on the current *mode* to handle the corresponding logic.
